### PR TITLE
set-sms-region-india: region is now an ENV variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN chown -R ${APP_USER}:${APP_USER} ${APP_DIR}
 # Copy AWS template
 RUN mkdir -p /home/${APP_USER}/.aws
 COPY ./credentials /home/${APP_USER}/.aws/credentials_template
-COPY ./config /home/${APP_USER}/.aws/config
+COPY ./config /home/${APP_USER}/.aws/config_template
 RUN chown -R ${APP_USER}:${APP_USER} /home/${APP_USER}/.aws
 
 # Copy entrypoint code

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -38,7 +38,7 @@ RUN chown -R ${APP_USER}:${APP_USER} ${APP_DIR}
 # Copy AWS template
 RUN mkdir -p /home/${APP_USER}/.aws
 COPY ./credentials /home/${APP_USER}/.aws/credentials_template
-COPY ./config /home/${APP_USER}/.aws/config
+COPY ./config /home/${APP_USER}/.aws/config_template
 RUN chown -R ${APP_USER}:${APP_USER} /home/${APP_USER}/.aws
 
 # Copy entrypoint code

--- a/config
+++ b/config
@@ -1,2 +1,2 @@
 [default]
-region=eu-west-2 # Europe (London)
+region=AWS_REGION

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
 cp $HOME/.aws/credentials_template $HOME/.aws/credentials
 sed -i "s|AWS_ACCESS_KEY_ID|${AWS_ACCESS_KEY_ID}|" $HOME/.aws/credentials
 sed -i "s|AWS_SECRET_ACCESS_KEY|${AWS_SECRET_ACCESS_KEY}|" $HOME/.aws/credentials
+
+cp $HOME/.aws/config_template $HOME/.aws/config
+sed -i "s|AWS_REGION|${AWS_REGION}|" $HOME/.aws/config


### PR DESCRIPTION
By setting `AWS_REGION` in the `.env` file, the user can set the region the SMS server operates from.

Region codes can be found from: https://docs.aws.amazon.com/sns/latest/dg/sns-supported-regions-countries.html